### PR TITLE
Lazy-load images on index page

### DIFF
--- a/frontend/components/Posts/Page/PostCard/featureImage.js
+++ b/frontend/components/Posts/Page/PostCard/featureImage.js
@@ -1,0 +1,26 @@
+import fetch from 'isomorphic-unfetch'
+import React, { Component, Children, useEffect, useState } from 'react';
+import LinearProgress from '@material-ui/core/LinearProgress';
+import styled from 'styled-components'
+import API from '../../../../api'
+
+function FeatureImage({featureImgUrl}) {
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+
+    }, [loading]);
+
+    return (
+        <>
+            <img
+                src={API.url + featureImgUrl}
+                onLoad={() => setLoading(false)}
+            />
+            {loading && <LinearProgress />}
+        </>
+    )
+
+}
+
+export default FeatureImage;

--- a/frontend/components/Posts/Page/PostCard/postCard.js
+++ b/frontend/components/Posts/Page/PostCard/postCard.js
@@ -5,14 +5,20 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import SCtheme from '../../../../assests/theme/SCtheme'
-import {StyledCard} from './postCardStyled'
+import {StyledImageWrapper, StyledCard} from './postCardStyled'
+import LazyLoad from 'react-lazyload'
+import FeatureImage from './featureImage'
 import API from '../../../../api';
 
 export const PostCard = ({ post }) => {
     return(
         <StyledCard>
             <CardContent>
-                <img src={API.url + post.featureImgUrl}></img>
+                <LazyLoad height={'400px'} >
+                    <StyledImageWrapper>
+                        <FeatureImage featureImgUrl={post.featureImgUrl} />
+                    </StyledImageWrapper>
+                </LazyLoad>
                 <Typography color="textPrimary" gutterBottom>
                     {post.title}
                 </Typography>

--- a/frontend/components/Posts/Page/PostCard/postCard.js
+++ b/frontend/components/Posts/Page/PostCard/postCard.js
@@ -5,18 +5,8 @@ import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 import Typography from '@material-ui/core/Typography';
 import SCtheme from '../../../../assests/theme/SCtheme'
+import {StyledCard} from './postCardStyled'
 import API from '../../../../api';
-
-
-const StyledCard = styled(Card)`
-    margin-bottom: 10px;
-    background-color: ${SCtheme.backgroundDarkAlt};
-    transition: transform 0.2s ease-in-out !important;
-    &:hover {
-        cursor: pointer;
-        transform: scale(1.008);
-    }
-`
 
 export const PostCard = ({ post }) => {
     return(

--- a/frontend/components/Posts/Page/PostCard/postCardStyled.js
+++ b/frontend/components/Posts/Page/PostCard/postCardStyled.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import Card from '@material-ui/core/Card';
+import SCtheme from '../../../../assests/theme/SCtheme'
+
+export const StyledCard = styled(Card)`
+    margin-bottom: 10px;
+    background-color: ${SCtheme.backgroundDarkAlt};
+    transition: transform 0.2s ease-in-out !important;
+    &:hover {
+        cursor: pointer;
+        transform: scale(1.008);
+    }
+`

--- a/frontend/components/Posts/Page/PostCard/postCardStyled.js
+++ b/frontend/components/Posts/Page/PostCard/postCardStyled.js
@@ -11,3 +11,7 @@ export const StyledCard = styled(Card)`
         transform: scale(1.008);
     }
 `
+
+export const StyledImageWrapper = styled.div`
+    min-height: 400px;
+`;

--- a/frontend/components/Posts/Page/page.js
+++ b/frontend/components/Posts/Page/page.js
@@ -13,23 +13,6 @@ import SCtheme from '../../../assests/theme/SCtheme'
 import API from '../../../api';
 import {PostCard} from './PostCard/postCard'
 
-const useStyles = makeStyles({
-root: {
-    minWidth: 275,
-},
-bullet: {
-    display: 'inline-block',
-    margin: '0 2px',
-    transform: 'scale(0.8)',
-},
-title: {
-    fontSize: 14,
-},
-pos: {
-    marginBottom: 12,
-},
-});
-
 const PostCardLink = React.forwardRef((props, ref) => (
 <a ref={ref} {...props}>
     

--- a/frontend/components/Posts/postsContainer.js
+++ b/frontend/components/Posts/postsContainer.js
@@ -18,18 +18,19 @@ const PostContainer = ({className, children}) => {
     
   }
   
-  const StyledPost = styled(PostContainer)`
-    width: 95%;
-    max-width: 900px;
-  `
+const StyledPost = styled(PostContainer)`
+width: 95%;
+max-width: 900px;
+`
 
-function PostsContainer() {
+function PostsContainer({ buildPosts }) {
     const [tempID, setTempID] = useState(-1);
     const [minID, setMinID] = useState(-1);
     const [children, setChildren] = useState([]);
     const [success, setSuccess] = useState(true);
     const [posts, setPosts] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [build, setBuild] = useState(true);
 
     const loadMorePosts = () => {
         console.log("Loading more posts");
@@ -38,26 +39,37 @@ function PostsContainer() {
         setMinID(tempID);
     };
 
-    useEffect(() => {
-        const jsonBody = {
-            maxID: minID.toString()
-        }
-        fetch(API.url+'/api/v1/posts/get', {
-            method: 'post',
-            body: JSON.stringify(jsonBody)
-        })
-        .then(res => res.json())
-        .then(response => {
-            if(response.success) {
-                setPosts(response.data);
-                setTempID(response.pagination.minID);
-                setChildren(oldChildren => [...oldChildren, <Page posts={response.data}/>])
-            }
-            setIsLoading(false);
-            setSuccess(response.success);
 
-        })
-        .catch(error => console.log(error));
+    useEffect(() => {
+        if (minID != -1) {
+            
+            const jsonBody = {
+                maxID: minID.toString()
+            }
+            fetch(API.url+'/api/v1/posts/get', {
+                method: 'post',
+                body: JSON.stringify(jsonBody)
+            })
+            .then(res => res.json())
+            .then(response => {
+                if(response.success) {
+                    setPosts(response.data);
+                    setTempID(response.pagination.minID);
+                    setChildren(oldChildren => [...oldChildren, <Page posts={response.data}/>]);
+                }
+                setIsLoading(false);
+                setSuccess(response.success);
+
+            })
+            .catch(error => console.log(error));
+        } else {
+            setPosts(buildPosts.data);
+            setTempID(buildPosts.pagination.minID);
+            setChildren([<Page posts={buildPosts.data}/>]);
+            setBuild(false);
+            setIsLoading(false);
+            setSuccess(buildPosts.success);
+        }
     }, [minID]);
 
     return (
@@ -81,5 +93,6 @@ function PostsContainer() {
     )
 }
 
+// TODO: use getStaticProps
 
 export default PostsContainer;

--- a/frontend/components/Posts/postsContainer.js
+++ b/frontend/components/Posts/postsContainer.js
@@ -63,11 +63,13 @@ function PostsContainer({ buildPosts }) {
             })
             .catch(error => console.log(error));
         } else {
-            setPosts(buildPosts.data);
-            setTempID(buildPosts.pagination.minID);
-            setChildren([<Page posts={buildPosts.data}/>]);
-            setBuild(false);
-            setIsLoading(false);
+            if(buildPosts.success) {
+                setPosts(buildPosts.data);
+                setTempID(buildPosts.pagination.minID);
+                setChildren([<Page posts={buildPosts.data}/>]);
+                setBuild(false);
+                setIsLoading(false);
+            }
             setSuccess(buildPosts.success);
         }
     }, [minID]);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8850,6 +8850,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
+    "react-lazyload": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/react-lazyload/-/react-lazyload-2.6.8.tgz",
+      "integrity": "sha512-21iCBeqe8FSjgRxYuf0lt0iyiT451+No9kHHJO/TdyeH2oLoabpMX/mBG81BQBQ17S8pqfD/13YSihw1zWBzhw=="
+    },
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "next-offline": "^5.0.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-lazyload": "^2.6.8",
     "react-waypoint": "^9.0.2",
     "styled-components": "^5.1.1",
     "uuid": "^7.0.3"

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -6,10 +6,10 @@ import dateFormat from 'dateformat'
 import Error from 'next/error'
 import API from '../../../../api'
 
-const Index = ({errorCode, props}) => {
-  console.log(errorCode);
-  if (errorCode) {
-    return <Error statusCode={errorCode} />
+const Index = props => {
+  console.log(props.errorCode);
+  if (props.errorCode) {
+    return <Error statusCode={props.errorCode} />
   }
   return (
     <Layout>
@@ -36,9 +36,9 @@ const Index = ({errorCode, props}) => {
   
 };
 
-Index.getInitialProps = async ctx => {
+export async function getServerSideProps(context) {
 
-  let res = await fetch(`${API.url}/api/v1/posts${ctx.asPath}`);
+  let res = await fetch(`${API.url}/api/v1/posts/${context.params.year}/${context.params.month}/${context.params.slug}`);
 
   const post = await res.json();
 
@@ -48,7 +48,12 @@ Index.getInitialProps = async ctx => {
 
   if(errorCode) {
     console.log("bad slug");
-    return {errorCode, post: post};
+    return {
+      props: {
+        errorCode: errorCode,
+        post: post
+      }
+    };
   }
   
 
@@ -63,8 +68,8 @@ Index.getInitialProps = async ctx => {
   const author = await resAuthor.json();
 
   return {
-    errorCode,
     props: {
+      errorCode: errorCode,
       post: post,
       month: dateFormat(dateStr, "mmmm"),
       day: dateFormat(dateStr, "dd"),

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -140,8 +140,8 @@ const Index = props => (
         
 );
 
-// TODO: use getStaticProps
-export async function getStaticProps() {
+// TODO: use getServerSideProps
+export async function getServerSideProps() {
   // Call API
   const jsonBody = {
     maxID: "-1"

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -12,6 +12,7 @@ import Grid from '@material-ui/core/Grid';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
 import {AppBar, Toolbar, IconButton, Typography, Hidden, CssBaseline} from '@material-ui/core'
 import PostsContainer from '../components/Posts/postsContainer'
+import API from '../api'
 
 const Container = styled.div`
   width: 960px;
@@ -134,10 +135,29 @@ function HideOnScroll(props) {
 const Index = props => (
         
   <Layout> 
-      <PostsContainer></PostsContainer>        
+      <PostsContainer buildPosts={props.buildPosts}></PostsContainer>        
   </Layout>
         
 );
+
+// TODO: use getStaticProps
+export async function getStaticProps() {
+  // Call API
+  const jsonBody = {
+    maxID: "-1"
+  }
+  const res = await fetch(API.url+'/api/v1/posts/get', {
+    method: 'post',
+    body: JSON.stringify(jsonBody)
+  })
+  const posts = await res.json()
+
+  return {
+    props: {
+      buildPosts: posts
+    }
+  }
+}
 
 export default Index;
   


### PR DESCRIPTION
Closes #26, #31, and #32  

Added a custom component using hooks to add feedback when the image is loading. There is also a wrapper that forces a min-height of 400px, which will likely be the standard going forward. The same solution will be applied to the individual post page in the future, but it is not currently the priority.